### PR TITLE
Feature/common: 공통 로직 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,11 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### yml ###
 application-*
+
+### macOS ###
+.DS_Store
 
 ### STS ###
 .apt_generated

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:17-jdk
-COPY build/libs/emailer-0.0.1-SNAPSHOT.jar emailer.jar
+COPY build/libs/maeilmail-0.0.1-SNAPSHOT.jar maeilmail.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/emailer.jar"]
+ENTRYPOINT ["java", "-jar", "/maeilmail.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   emailer:
-    image: emailer
+    image: maeilmail
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/src/main/java/mongkey/maeilmail/MaeilmailApplication.java
+++ b/src/main/java/mongkey/maeilmail/MaeilmailApplication.java
@@ -1,13 +1,13 @@
-package team36.emailer;
+package mongkey.maeilmail;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class EmailerApplication {
+public class MaeilmailApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(EmailerApplication.class, args);
+        SpringApplication.run(MaeilmailApplication.class, args);
     }
 
 }

--- a/src/main/java/mongkey/maeilmail/common/domain/BaseTimeEntity.java
+++ b/src/main/java/mongkey/maeilmail/common/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package mongkey.maeilmail.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    LocalDateTime created_at;
+
+    @LastModifiedDate
+    LocalDateTime updated_at;
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/ApiException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/ApiException.java
@@ -1,0 +1,15 @@
+package mongkey.maeilmail.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public abstract class ApiException extends ResponseStatusException {
+    private final boolean success;
+    private final Object data;
+    public ApiException(final HttpStatus code, final String message, final Object data) {
+        super(code, message);
+        this.success = false;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/ConflictException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/ConflictException.java
@@ -1,0 +1,13 @@
+package mongkey.maeilmail.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public abstract class ConflictException extends ApiException {
+    public ConflictException(final String message) {
+        super(CONFLICT, message, null);
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/ForbiddenException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+package mongkey.maeilmail.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public abstract class ForbiddenException extends ApiException {
+    public ForbiddenException(final String message) {
+        super(HttpStatus.FORBIDDEN, message, null);
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/InternalServerErrorException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/InternalServerErrorException.java
@@ -1,0 +1,13 @@
+package mongkey.maeilmail.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public abstract class InternalServerErrorException extends ApiException{
+    public InternalServerErrorException (final String message) {
+        super(INTERNAL_SERVER_ERROR, message, null);
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/NotFoundException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package mongkey.maeilmail.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+
+public abstract class NotFoundException extends ApiException {
+    public NotFoundException(final String message) {
+        super(HttpStatus.NOT_FOUND, message, null);
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/exception/UnauthorizedException.java
+++ b/src/main/java/mongkey/maeilmail/common/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package mongkey.maeilmail.common.exception;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public abstract class UnauthorizedException extends ApiException {
+    public UnauthorizedException(final String message) {
+        super(UNAUTHORIZED, message, null);
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/response/ApiResponse.java
+++ b/src/main/java/mongkey/maeilmail/common/response/ApiResponse.java
@@ -1,0 +1,90 @@
+package mongkey.maeilmail.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final int code;
+    private final boolean success;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(
+                Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getHttpStatus().is2xxSuccessful(),
+                Success.SUCCESS.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> success(Success success) {
+        return new ApiResponse<>(
+                success.getHttpStatusCode(),
+                success.getHttpStatus().is2xxSuccessful(),
+                success.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> success(Success success, T data) {
+        return new ApiResponse<>(
+                success.getHttpStatusCode(),
+                success.getHttpStatus().is2xxSuccessful(),
+                success.getMessage(),
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(
+                Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getHttpStatus().is2xxSuccessful(),
+                Success.SUCCESS.getMessage(),
+                data
+        );
+    }
+
+
+    public static <T> ApiResponse<T> failure(Error error) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
+                error.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(Error error, String message) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
+                message,
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(Error error, T data) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
+                error.getMessage(),
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(T data) {
+        return new ApiResponse<>(
+                Error.ERROR.getHttpStatusCode(),
+                Error.ERROR.getHttpStatus().is2xxSuccessful(),
+                Error.ERROR.getMessage(),
+                data
+        );
+    }
+
+}

--- a/src/main/java/mongkey/maeilmail/common/response/Error.java
+++ b/src/main/java/mongkey/maeilmail/common/response/Error.java
@@ -1,0 +1,43 @@
+package mongkey.maeilmail.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Error {
+
+    // Default
+    ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
+
+
+    //403 Forbidden
+    NO_PERMISSION_TO_POST(HttpStatus.FORBIDDEN, "게시글을 수정하거나 삭제할 권한이 없습니다."),
+
+
+    // 404 NOT FOUND
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "액세스 토큰 정보를 찾을 수 없습니다."),
+
+
+
+    // 409 CONFLICT
+    NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "해당 닉네임을 가진 유저가 이미 존재합니다."),
+
+
+
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    ;
+
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/mongkey/maeilmail/common/response/Success.java
+++ b/src/main/java/mongkey/maeilmail/common/response/Success.java
@@ -1,0 +1,35 @@
+package mongkey.maeilmail.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Success {
+
+    // Default
+    SUCCESS(HttpStatus.OK, "Request successfully processed"),
+
+
+    //200 SUCCESS
+    GET_ONE_POST_SUCCESS(HttpStatus.OK, "하나의 게시글을 성공적으로 조회하였습니다."),
+
+
+
+
+    //201 CREATED SUCCESS
+    CREATE_POST_SUCCESS(HttpStatus.CREATED, "게시글을 성공적으로 등록하였습니다."),
+
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/mongkey/maeilmail/config/handler/GlobalExceptionHandler.java
+++ b/src/main/java/mongkey/maeilmail/config/handler/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package  mongkey.maeilmail.config.handler;
+
+import mongkey.maeilmail.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<Object> handleApiException(ApiException ex, WebRequest request) {
+        Map<String, Object> responseBody = new LinkedHashMap<>();
+
+        responseBody.put("code", ex.getStatusCode().value());
+        responseBody.put("success", ex.getStatusCode().is2xxSuccessful());
+        responseBody.put("message", ex.getBody().getDetail());
+        responseBody.put("data",null);
+
+        return new ResponseEntity<>(responseBody, HttpStatus.valueOf(ex.getStatusCode().value()));
+
+    }
+
+
+}

--- a/src/test/java/mongkey/maeilmail/MaeilmailApplicationTests.java
+++ b/src/test/java/mongkey/maeilmail/MaeilmailApplicationTests.java
@@ -1,10 +1,10 @@
-package team36.emailer;
+package mongkey.maeilmail;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class EmailerApplicationTests {
+class MaeilmailApplicationTests {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
`BaseTimeEntity`
- created_at, updated_at 을 자동으로 생성 및 수정하는 base time entity를 작성하였습니다.
- 해당 칼럼이 필요한 엔티티에서 상속하여 사용합니다.


`Response`
- 클라이언트의 요청 처리 중 예외 발생시 사용하는 응답 형식을 설정하였습니다.
- code(int), success(boolean), message(string), data 로 구성하였습니다. 
- 성공 메세지와 에러 메세지를 저장하는 Success.java, Error.java 이넘 클래스를 작성하였습니다.
- 위에서 언급한 두 클래스에 적절한 메세지를 입력해 사용합니다


`Exception`
- 예외처리를 위한 GlobalExceptionHandler를 작성하였습니다. 
- 시스템 오류나 프로그래밍 오류 등 발생시 사용하는 예외 형식을 설정하였습니다.
- 세부 형식은 response 형식과 동일합니다.
- conflict, forbidden 등 5개의 exception을 구현하였으며, 필요시 구현하여 사용합니다.

